### PR TITLE
feat: delete many alerts

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -126,6 +126,14 @@ app.delete('/alert/:id', async (req, res) => {
     res.json(user)
 })
 
+app.delete('/alert', async (req, res) => {
+
+    const filter = req.body
+
+    const user = await alertManager.delete(filter)
+
+    res.json(user)
+})
 
 // * TOKENS
 


### PR DESCRIPTION
To delete many alerts at once you should:

* Make a DELETE request to /alert
* The body of the request should be the filter of the query, e.g: ```{userId: "1234567890"}```

It will return the result of the mongo operation i.e. how many elements were deleted, etc